### PR TITLE
Add downgrade and Canary upgrade scripts

### DIFF
--- a/scripts/1.3.12/README.md
+++ b/scripts/1.3.12/README.md
@@ -1,0 +1,77 @@
+# Scripts for v1.3.12
+
+### Upgrade (only for Canary)
+
+Required to upgrade the Canary from any version above 1.3.4 to 1.3.12.
+
+This script is needed to be able to discover DBMSs installed with older versions of Desktop correctly. Without running this, you'll see the DBMSs in your projects, but won't be able to start them. The script is only changing Desktop configuration and is not modifying any data.
+
+- Start the upgraded version of Neo4j Desktop.
+- Once it's done loading close the application.
+- Run the script.
+- Start Neo4j Desktop again.
+
+### Downgrade
+
+Required to downgrade from 1.3.12 to any older version. The script needs to be executed after closing Neo4j Desktop 1.3.12 and before starting the older version.
+
+This script is needed for projects to be discovered correctly by older versions of Desktop. Without it, you won't be able to startup Desktop (as it won't find the project you last opened). The script is removing some symbolic links and metadata used by Desktop, no data is modified by it.
+
+**Projects directory not found**
+
+If running the script returns an error about the "projects" directory not existing, you'll have to get the data path from Desktop 1.3.12. To do so follow the steps
+below.
+
+- Start Desktop and click on Developer > Developer Tools.
+- Run the following line in the console tab and copy the result:
+
+```
+require('electron').remote.app.relateEnvironment.dataPath
+```
+
+- In the terminal where you ran the script add an environment variable containing the path you just copied:
+
+```
+# Windows
+$env:NEO4J_RELATE_DATA_HOME = "copied-path"
+
+# Mac & Linux
+export NEO4J_RELATE_DATA_HOME="copied-path"
+```
+
+- Run the script again and close the terminal.
+
+## Running scripts
+
+### Windows
+
+Download the script you need. Open a Powershell window in the folder where the file is downloaded\* and run the following:
+
+```powershell
+Powershell -ExecutionPolicy Bypass -File ./script-name.ps1
+```
+
+\* In the file explorer you can hold shift, right click, and then click "Open PowerShell window here".
+
+### Mac & Linux
+
+Download the script you need. Open a terminal in the folder where the file is downloaded and run the following:
+
+```shell
+chmod +x script-name.sh
+./script-name.sh
+```
+
+## Downloads
+
+Right click any of the links below and click "Save link as..."
+
+**Windows**
+
+- [upgrade-canary.ps1](https://github.com/neo4j-devtools/neo4j-desktop/raw/master/scripts/1.3.12/upgrade-canary.ps1)
+- [downgrade.ps1](https://github.com/neo4j-devtools/neo4j-desktop/raw/master/scripts/1.3.12/downgrade.ps1)
+
+**Mac & Linux**
+
+- [upgrade-canary.sh](https://github.com/neo4j-devtools/neo4j-desktop/raw/master/scripts/1.3.12/upgrade-canary.sh)
+- [downgrade.sh](https://github.com/neo4j-devtools/neo4j-desktop/raw/master/scripts/1.3.12/upgrade-canary.sh)

--- a/scripts/1.3.12/downgrade.ps1
+++ b/scripts/1.3.12/downgrade.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = "Stop"
+
+$relate_data_path = "$env:USERPROFILE\AppData\Local\Neo4j\Relate\Data"
+if ($env:LOCALAPPDATA) {
+    $relate_data_path = "$env:LOCALAPPDATA\Neo4j\Relate\Data"
+}
+if ($env:NEO4J_RELATE_DATA_HOME) {
+    $relate_data_path = "$env:NEO4J_RELATE_DATA_HOME"
+}
+
+$projects_path = "$relate_data_path\projects"
+Get-ChildItem "$projects_path" | Where-Object { $_.LinkType } | ForEach-Object -Process {
+    Remove-Item "$projects_path\$_\relate.project.json" -Force -ErrorAction Ignore
+    # Remove symbolic link https://superuser.com/a/595197
+    cmd /c rmdir "$projects_path\$_"
+}
+
+Write-Output "Unlinked projects"

--- a/scripts/1.3.12/downgrade.sh
+++ b/scripts/1.3.12/downgrade.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  relate_data_path="$HOME/Library/Application Support/com.Neo4j.Relate/Data"
+  [[ "$XDG_DATA_HOME" != "" ]] && relate_data_path="$XDG_DATA_HOME/com.Neo4j.Relate"
+  [[ "$NEO4J_RELATE_DATA_HOME" != "" ]] && relate_data_path="$NEO4J_RELATE_DATA_HOME"
+else
+  relate_data_path="$HOME/.local/share/neo4j-relate"
+  [[ "$XDG_DATA_HOME" != "" ]] && relate_data_path="$XDG_DATA_HOME/neo4j-relate"
+  [[ "$NEO4J_RELATE_DATA_HOME" != "" ]] && relate_data_path="$NEO4J_RELATE_DATA_HOME"
+fi
+
+projects=$(ls "$relate_data_path/projects/")
+
+for project in $projects; do
+  rm -f "$relate_data_path/projects/$project/relate.project.json"
+  rm "$relate_data_path/projects/$project"
+done
+
+echo "Unlinked projects"

--- a/scripts/1.3.12/upgrade-canary.ps1
+++ b/scripts/1.3.12/upgrade-canary.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = "Stop"
+
+$relate_config_path = "$env:USERPROFILE\AppData\Roaming\Neo4j\Relate\Config"
+if ($env:APPDATA) {
+    $relate_config_path = "$env:APPDATA\Neo4j\Relate\Config"
+}
+if ($env:NEO4J_RELATE_DATA_HOME) {
+    $relate_config_path = "$env:NEO4J_RELATE_DATA_HOME"
+}
+
+$env_name = "Neo4j_Desktop_Canary"
+$env_config_path = "$relate_config_path\environments\$env_name.json"
+
+$env_config = Get-Content "$env_config_path" -raw | ConvertFrom-Json
+
+$env_config.PSObject.Properties.Remove('configPath')
+$env_config.PSObject.Properties.Remove('relateDataPath')
+
+$env_config | ConvertTo-Json | Set-Content "$env_config_path"
+
+Write-Output "Environment updated"

--- a/scripts/1.3.12/upgrade-canary.sh
+++ b/scripts/1.3.12/upgrade-canary.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    relate_config_path="$HOME/Library/Application Support/com.Neo4j.Relate/Config"
+    [[ "$XDG_CONFIG_HOME" != "" ]] && relate_config_path="$XDG_CONFIG_HOME/com.Neo4j.Relate"
+    [[ "$NEO4J_RELATE_CONFIG_HOME" != "" ]] && relate_config_path="$NEO4J_RELATE_CONFIG_HOME"
+else
+    relate_config_path="$HOME/.config/neo4j-relate"
+    [[ "$XDG_CONFIG_HOME" != "" ]] && relate_config_path="$XDG_CONFIG_HOME/neo4j-relate"
+    [[ "$NEO4J_RELATE_CONFIG_HOME" != "" ]] && relate_config_path="$NEO4J_RELATE_CONFIG_HOME"
+fi
+
+tmp_file=$(mktemp)
+env_name="Neo4j_Desktop_Canary"
+env_config_path="$relate_config_path/environments/$env_name.json"
+
+sed -i 's/"configPath":\s*"[^"]*",//' "$env_config_path"
+sed -i 's/"relateDataPath":\s*"[^"]*",//' "$env_config_path"
+
+echo "Environment updated"


### PR DESCRIPTION
Add scripts and instructions for upgrading Neo4j Desktop Canary to 1.3.12 and for downgrading from 1.3.12. 

I removed a dependency on the bash scripts for upgrading the Canary. I tested the change on Linux, but it needs to be tested on Mac as well (sed has some differences between them, so we want to make sure it works properly before merging this). 

To test it you can start a fresh install of Desktop from `74e8ad82`, add some projects/dbmss/files, rename `Neo4j_Desktop_Canary` to `Neo4j_Desktop_Development` in the script, and follow the instructions in the [readme](https://github.com/neo4j-devtools/neo4j-desktop/blob/ab202bb40ccc29547520d5b749c106d5fe8967ed/scripts/1.3.12/README.md) to upgrade.  